### PR TITLE
imageloader加载图片使用memory缓存

### DIFF
--- a/library/src/main/java/cn/finalteam/rxgalleryfinal/imageloader/UniversalImageLoader.java
+++ b/library/src/main/java/cn/finalteam/rxgalleryfinal/imageloader/UniversalImageLoader.java
@@ -23,6 +23,7 @@ public class UniversalImageLoader implements AbsImageLoader {
         if (displayImageOptions == null) {
             displayImageOptions = new DisplayImageOptions.Builder()
                     .cacheOnDisk(false)
+                    .cacheInMemory(true)
                     .bitmapConfig(config)
                     .showImageOnFail(defaultDrawable)
                     .showImageOnLoading(defaultDrawable)


### PR DESCRIPTION
防止内存溢出问题