### PR TITLE
增加takePicCrop配置项

### DIFF
--- a/library/src/main/java/cn/finalteam/rxgalleryfinal/Configuration.java
+++ b/library/src/main/java/cn/finalteam/rxgalleryfinal/Configuration.java
@@ -48,6 +48,7 @@ public class Configuration implements Parcelable {
     private int imageLoaderType;
     private int imageConfig;
     private boolean hideCamera;
+    private boolean takePicCrop;//画廊中选择相机拍摄照片后直接打开裁剪
     private boolean isPlayGif;
     private boolean hidePreview;
     private boolean isVideoPreview;
@@ -104,6 +105,7 @@ public class Configuration implements Parcelable {
         imageLoaderType = in.readInt();
         imageConfig = in.readInt();
         hideCamera = in.readByte() != 0;
+        takePicCrop = in.readByte() != 0;
         isPlayGif = in.readByte() != 0;
         hidePreview = in.readByte() != 0;
         isVideoPreview = in.readByte() != 0;
@@ -171,6 +173,13 @@ public class Configuration implements Parcelable {
 
     public void setHideCamera(boolean hideCamera) {
         this.hideCamera = hideCamera;
+    }
+    public boolean isTakePicCrop() {
+        return takePicCrop;
+    }
+
+    public void setTakePicCrop(boolean takePicCrop) {
+        this.takePicCrop = takePicCrop;
     }
 
     //#ADD
@@ -364,6 +373,7 @@ public class Configuration implements Parcelable {
         parcel.writeInt(imageLoaderType);
         parcel.writeInt(imageConfig);
         parcel.writeByte((byte) (hideCamera ? 1 : 0));
+        parcel.writeByte((byte) (takePicCrop ? 1 : 0));
         parcel.writeByte((byte) (isPlayGif ? 1 : 0));
         parcel.writeByte((byte) (hidePreview ? 1 : 0));
         parcel.writeByte((byte) (isVideoPreview ? 1 : 0));

--- a/library/src/main/java/cn/finalteam/rxgalleryfinal/RxGalleryFinal.java
+++ b/library/src/main/java/cn/finalteam/rxgalleryfinal/RxGalleryFinal.java
@@ -155,6 +155,16 @@ public class RxGalleryFinal {
     }
 
     /**
+     * 相册中选择拍摄照片后直接打开裁剪
+     * 如果不调用该方法，默认回到相册
+     */
+    public RxGalleryFinal takePicCrop() {
+        configuration.setHideCamera(false);
+        configuration.setTakePicCrop(true);
+        return this;
+    }
+
+    /**
      * set to true to hide the bottom controls (shown by default)
      */
     public RxGalleryFinal cropHideBottomControls(boolean hide) {

--- a/library/src/main/java/cn/finalteam/rxgalleryfinal/ui/fragment/MediaGridFragment.java
+++ b/library/src/main/java/cn/finalteam/rxgalleryfinal/ui/fragment/MediaGridFragment.java
@@ -845,6 +845,9 @@ public class MediaGridFragment extends BaseFragment implements MediaGridView, Re
                             if (bk != -1) {
                                 mMediaBeanList.add(1, mediaBean);
                                 mMediaGridAdapter.notifyDataSetChanged();
+                                if (mConfiguration.isTakePicCrop()) {
+                                    onObItemClick(1);
+                                }
                             } else {
                                 Logger.i("获取：无");
                             }

--- a/sample/src/main/java/cn/finalteam/rxgalleryfinal/sample/MainActivity.java
+++ b/sample/src/main/java/cn/finalteam/rxgalleryfinal/sample/MainActivity.java
@@ -247,6 +247,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 .radio()
                 .cropAspectRatioOptions(0, new AspectRatio("3:3", 30, 10))
                 .crop()
+                .takePicCrop()
                 .imageLoader(ImageLoaderType.FRESCO)
                 .subscribe(new RxBusResultDisposable<ImageRadioResultEvent>() {
                     @Override


### PR DESCRIPTION
用于画廊中选择相机拍摄照片后直接打开裁剪，而不是回到相册