### PR TITLE
Change method name 'concat' to 'addBasePath'

### DIFF
--- a/library/src/main/java/cn/finalteam/rxgalleryfinal/utils/FilenameUtils.java
+++ b/library/src/main/java/cn/finalteam/rxgalleryfinal/utils/FilenameUtils.java
@@ -469,7 +469,7 @@ public class FilenameUtils {
      * @param fullFilenameToAdd the filename (or path) to attach to the base
      * @return the concatenated path, or null if invalid
      */
-    public static String concat(String basePath, String fullFilenameToAdd) {
+    public static String addBasePath(String basePath, String fullFilenameToAdd) {
         int prefix = getPrefixLength(fullFilenameToAdd);
         if (prefix < 0) {
             return null;


### PR DESCRIPTION
This class is used to represent FilenameUtils.  This method named 'concat' is to add the base path to the current one. Thus, the method name 'addBasePath' is more intuitive than 'concat'.